### PR TITLE
Add a value error type

### DIFF
--- a/value.go
+++ b/value.go
@@ -1,0 +1,70 @@
+package xerrors
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// WithValue adds a value to an error.
+func WithValue(err error, key string, val interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return &value{
+		err:   err,
+		key:   key,
+		value: val,
+	}
+}
+
+type value struct {
+	err   error
+	key   string
+	value interface{}
+}
+
+// Format implements the fmt.Formatter interface.
+//
+// The verbs:
+//
+//	%s	an error
+//	%v	same as %s, the plus or hash flags print the value associated with the error
+func (err *value) Format(s fmt.State, verb rune) {
+	format(s, verb, err.err)
+	if verb == 'v' && (s.Flag('+') || s.Flag('#')) {
+		typeOf := reflect.TypeOf(err.value)
+		of := reflect.ValueOf(err.value)
+		switch typeOf.Kind() {
+		case reflect.Slice, reflect.Array, reflect.Chan, reflect.Map, reflect.String, reflect.Ptr:
+			_, _ = fmt.Fprintf(s, "\nvalue %q = (%s) (len=%d) \"%v\"", err.key, typeOf, of.Len(), of)
+		default:
+			_, _ = fmt.Fprintf(s, "\nvalue %q = (%s) \"%v\"", err.key, typeOf, of)
+		}
+	}
+}
+
+func (err *value) Value() (key string, value interface{}) {
+	return err.key, err.value
+}
+
+func (err *value) Error() string { return err.err.Error() }
+func (err *value) Unwrap() error { return err.err }
+
+// Values returns the values associated to an error.
+func Values(err error) map[string]interface{} {
+	vals := make(map[string]interface{})
+	for ; err != nil; err = errors.Unwrap(err) {
+		err, ok := err.(*value)
+		if !ok {
+			continue
+		}
+		k, v := err.Value()
+		_, ok = vals[k]
+		if ok {
+			continue
+		}
+		vals[k] = v
+	}
+	return vals
+}

--- a/value_test.go
+++ b/value_test.go
@@ -1,0 +1,79 @@
+package xerrors
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestValue(t *testing.T) {
+	err := New("error")
+	err = WithValue(err, "foo", "bar")
+	vals := Values(err)
+	want := map[string]interface{}{
+		"foo": "bar",
+	}
+	if !reflect.DeepEqual(vals, want) {
+		t.Errorf("Values() = %v, want %v", vals, want)
+	}
+}
+
+func TestValueOverWrite(t *testing.T) {
+	err := New("error")
+	err = WithValue(err, "test", 1)
+	err = WithValue(err, "test", 2)
+	vals := Values(err)
+	want := map[string]interface{}{
+		"test": 2,
+	}
+	if !reflect.DeepEqual(vals, want) {
+		t.Errorf("Values() = %v, want %v", vals, want)
+	}
+}
+
+func TestValueNil(t *testing.T) {
+	err := WithValue(nil, "foo", "bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValuesEmpty(t *testing.T) {
+	err := New("error")
+	vals := Values(err)
+	if len(vals) != 0 {
+		t.Fatalf("values not empty: got %#v", vals)
+	}
+}
+
+func TestValueError(t *testing.T) {
+	err := New("error")
+	err = WithValue(err, "foo", "bar")
+	s := fmt.Sprint(err)
+	want := "error"
+	if s != want {
+		t.Fatalf("unexpected message: got %q, want %q", s, want)
+	}
+}
+
+func TestValueFormat(t *testing.T) {
+	tests := []struct {
+		format string
+		value  interface{}
+		want   string
+	}{
+		{format: "%s", value: "bar", want: "error"},
+		{format: "%+v", value: "bar", want: "error\nvalue \"foo\" = (string) (len=3) \"bar\""},
+		{format: "%+v", value: 4, want: "error\nvalue \"foo\" = (int) \"4\""},
+	}
+	for n, tt := range tests {
+		t.Run(fmt.Sprintf("case-%d", n+1), func(t *testing.T) {
+			err := New("error")
+			err = WithValue(err, "foo", tt.value)
+			s := fmt.Sprintf(tt.format, err)
+			if s != tt.want {
+				t.Fatalf("unexpected message: got %q, want %q", s, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Greetings,

A way to add arbitrary values to an error chain would be nice to add context to an error chain, here is my proposal

- a `WithValue` method to add a value to an error chain
- a `Values` method to retrieve all the values from an error chain